### PR TITLE
config: allow auto-merge of Go minor updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,10 +30,10 @@
       "autoApprove": true
     },
     {
-      "description": "Auto-merge Go toolchain patch updates only",
+      "description": "Auto-merge Go toolchain patch and minor updates",
       "matchPackageNames": ["go"],
       "matchDatasources": ["golang-version"],
-      "matchUpdateTypes": ["patch"],
+      "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
       "autoApprove": true
     },


### PR DESCRIPTION
Update Renovate config to auto-merge both patch and minor Go toolchain updates. This prevents future Go minor updates (like 1.23.x -> 1.24.x) from requiring manual review and fixes.